### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/ransomware-remove/ee2469b5-9fa7-4f19-87c6-e69f1fcd6cb0/1e5e9b5c-db97-45d9-a19d-00398dff4817/_apis/work/boardbadge/dfd4b77a-143e-4766-838e-133fe8d9d8e1)](https://dev.azure.com/ransomware-remove/ee2469b5-9fa7-4f19-87c6-e69f1fcd6cb0/_boards/board/t/1e5e9b5c-db97-45d9-a19d-00398dff4817/Microsoft.RequirementCategory)
 bits tht have died,
 
 deathtobits


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/ransomware-remove/ee2469b5-9fa7-4f19-87c6-e69f1fcd6cb0/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.